### PR TITLE
Print mostlikely

### DIFF
--- a/src/globals.h
+++ b/src/globals.h
@@ -24,7 +24,9 @@ typedef struct {
     double result;              // The final (previous) function value
     double classical_exp;       // The classical expectation value of random sampling of the cost function
     double random_exp;          // Randomly sampling the entire QAOA domain (may be different to whole state-space)
+    double best_expectation;    // The best expectation value found
     double best_result;         // The best cost-value found over the entire optimisation scheme
+    double best_result_prob;    // The associated best probability with the best found result
     int max_value, max_index;   // The maximum value and index in the cost function generated
     int term_status;            // The nlopt termination status
     int num_evals;              // The number of evaluations used by the optimiser

--- a/src/qaoa.c
+++ b/src/qaoa.c
@@ -71,9 +71,9 @@ void optimiser_initialise(qaoa_data_t *meta_spec){
         meta_spec->opt_spec->upper_bounds[meta_spec->machine_spec->P] = 2 * (double) PI;
         meta_spec->opt_spec->lower_bounds[meta_spec->machine_spec->P] = 0.0;
         meta_spec->opt_spec->parameters[meta_spec->machine_spec->P] = (double) PI / 2.0;
-        nlopt_set_max_objective(meta_spec->opt_spec->optimiser, (nlopt_func) evolve, (void *) meta_spec);
-    } else {
         nlopt_set_max_objective(meta_spec->opt_spec->optimiser, (nlopt_func) evolve_restricted, (void *) meta_spec);
+    } else {
+        nlopt_set_max_objective(meta_spec->opt_spec->optimiser, (nlopt_func) evolve, (void *) meta_spec);
     }
     nlopt_set_lower_bounds(meta_spec->opt_spec->optimiser, meta_spec->opt_spec->lower_bounds);
     nlopt_set_upper_bounds(meta_spec->opt_spec->optimiser, meta_spec->opt_spec->upper_bounds);
@@ -86,7 +86,9 @@ void qaoa(machine_spec_t *mach_spec, cost_data_t *cost_data, optimisation_spec_t
     qaoa_data_t meta_spec;
     qaoa_statistics_t statistics;
     statistics.num_evals = 0;
+    statistics.best_expectation = -INFINITY;
     statistics.best_result = -INFINITY;
+    statistics.best_result_prob = -INFINITY;
     meta_spec.qaoa_statistics = &statistics;
     meta_spec.machine_spec = mach_spec;
     meta_spec.run_spec = run_spec;

--- a/src/reporting.c
+++ b/src/reporting.c
@@ -49,17 +49,17 @@ void timing_report(qaoa_statistics_t *statistics, FILE *outfile){
 void result_report(qaoa_statistics_t *statistics, FILE *outfile){
     fprintf(outfile, "Result report:\n"
                      "%d %d gOpt, Loc\n"
-                     "%f Final Result\n"
-                     "%f Best Result\n"
+                     "%f Final Expectation\n"
+                     "%f %f Best Result, Probability\n"
                      "%f Classical Exp\n"
                      "%f Initial Exp\n"
                      "%d Termination value\n",
-                     statistics->max_value, statistics->max_index,
-                     statistics->result,
-                     statistics->best_result,
-                     statistics->classical_exp,
-                     statistics->random_exp,
-                     statistics->term_status);
+            statistics->max_value, statistics->max_index,
+            statistics->result,
+            statistics->best_result, statistics->best_result_prob,
+            statistics->classical_exp,
+            statistics->random_exp,
+            statistics->term_status);
 }
 
 void optimiser_report(optimisation_spec_t *opt_spec, int P, FILE *outfile){


### PR DESCRIPTION
Separates best expectation value from best result seen. Accomplishes this by forcing sampling to occur but discarding the choices made only paying heed to the most likely outcome.